### PR TITLE
falcon: fstab: Mark cache and userdata as "formattable"

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -3,9 +3,9 @@
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 #<src>                                              <mnt_point>  <type>  <mnt_flags and options>                                                        <fs_mgr_flags>
 /dev/block/platform/msm_sdcc.1/by-name/system       /system      ext4    ro,barrier=1                                                                   wait
-/dev/block/platform/msm_sdcc.1/by-name/userdata     /data        ext4    rw,nosuid,nodev,noatime,nodiratime,noauto_da_alloc,nobarrier                   wait,check,encryptable=footer,length=-16384
-/dev/block/platform/msm_sdcc.1/by-name/userdata     /data        f2fs    rw,nosuid,nodev,noatime,nodiratime,inline_xattr                                wait,encryptable=footer,length=-16384
-/dev/block/platform/msm_sdcc.1/by-name/cache        /cache       ext4    rw,nosuid,nodev,noatime,nodiratime,data=writeback,noauto_da_alloc,barrier=1    wait,check
+/dev/block/platform/msm_sdcc.1/by-name/userdata     /data        ext4    rw,nosuid,nodev,noatime,nodiratime,noauto_da_alloc,nobarrier                   wait,check,formattable,encryptable=footer,length=-16384
+/dev/block/platform/msm_sdcc.1/by-name/userdata     /data        f2fs    rw,nosuid,nodev,noatime,nodiratime,inline_xattr                                wait,formattable,encryptable=footer,length=-16384
+/dev/block/platform/msm_sdcc.1/by-name/cache        /cache       ext4    rw,nosuid,nodev,noatime,nodiratime,data=writeback,noauto_da_alloc,barrier=1    wait,check,formattable
 /dev/block/platform/msm_sdcc.1/by-name/fsg          /fsg         ext4    ro,nosuid,nodev,barrier=0,context=u:object_r:firmware_file:s0                  wait,check
 /dev/block/platform/msm_sdcc.1/by-name/modem        /firmware    ext4    ro,nosuid,nodev,barrier=0,context=u:object_r:firmware_file:s0                  wait,check
 /dev/block/platform/msm_sdcc.1/by-name/persist      /persist     ext4    defaults                                                                       wait,check


### PR DESCRIPTION
Mark cache and userdata as formattable partitions, so that init/fs_mgr
format them during powerup if they are blank.

Change-Id: I6368a667d6535cf4258f616848a19ddc34a4fba6